### PR TITLE
Add reusable fluid container variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,7 @@ If you want to use a CDN version:
 <link rel="stylesheet" href="https://unpkg.com/@nenkan/css@0.10.0/dist/index.css">
 ```
 
-## Layout helpers
-
-- `.container`: centered fixed-width container.
-- `.container--fluid`: full-width container with responsive page gutters.
+Layout documentation is available under `docs/`.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import '@nenkan/css/dist/index.css'
 If you want to use a CDN version:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/@nenkan/css@0.10.0/dist/index.css">
+<link rel="stylesheet" href="https://unpkg.com/@nenkan/css@0.25.0/dist/index.css">
 ```
 
 Layout documentation is available under `docs/`.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ If you want to use a CDN version:
 <link rel="stylesheet" href="https://unpkg.com/@nenkan/css@0.10.0/dist/index.css">
 ```
 
+## Layout helpers
+
+- `.container`: centered fixed-width container.
+- `.container--fluid`: full-width container with responsive page gutters.
+
 ## Deployment
 
 Bump the `version` property in package.json. Make sure to update any other relevant files where a new version should be specified. Then, commit that and tag that commit with the version in the format: `vX.Y.Z`, where X is the major version, Y the minor version, and Z the patch version. For example: `v0.8.0`.

--- a/container.scss
+++ b/container.scss
@@ -9,3 +9,24 @@
     width: 100%;
   }
 }
+
+.container--fluid {
+  margin-left: variables.$space-unit-3;
+  margin-right: variables.$space-unit-3;
+  max-width: none;
+  width: auto;
+}
+
+@media screen and (min-width: 800px) {
+  .container--fluid {
+    margin-left: variables.$space-unit-4;
+    margin-right: variables.$space-unit-4;
+  }
+}
+
+@media screen and (min-width: 1240px) {
+  .container--fluid {
+    margin-left: calc(variables.$space-unit-4 + variables.$space-unit-2);
+    margin-right: calc(variables.$space-unit-4 + variables.$space-unit-2);
+  }
+}

--- a/container.scss
+++ b/container.scss
@@ -11,22 +11,23 @@
 }
 
 .container--fluid {
-  margin-left: variables.$space-unit-3;
-  margin-right: variables.$space-unit-3;
+  margin: 0;
   max-width: none;
-  width: auto;
+  padding-left: variables.$space-unit-3;
+  padding-right: variables.$space-unit-3;
+  width: 100%;
 }
 
 @media screen and (min-width: 800px) {
   .container--fluid {
-    margin-left: variables.$space-unit-4;
-    margin-right: variables.$space-unit-4;
+    padding-left: variables.$space-unit-4;
+    padding-right: variables.$space-unit-4;
   }
 }
 
 @media screen and (min-width: 1240px) {
   .container--fluid {
-    margin-left: calc(variables.$space-unit-4 + variables.$space-unit-2);
-    margin-right: calc(variables.$space-unit-4 + variables.$space-unit-2);
+    padding-left: calc(variables.$space-unit-4 + variables.$space-unit-2);
+    padding-right: calc(variables.$space-unit-4 + variables.$space-unit-2);
   }
 }

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -1,0 +1,4 @@
+# Layout helpers
+
+- `.container`: centered fixed-width container.
+- `.container--fluid`: full-width container with responsive page gutters.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nenkan/css",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nenkan/css",
-      "version": "0.24.1",
+      "version": "0.25.0",
       "license": "MIT",
       "devDependencies": {
         "sass": "^1.100.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nenkan/css",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "A set of styles shared by Nenkan applications",
   "main": "index.scss",
   "scripts": {


### PR DESCRIPTION
## Summary
- add .container--fluid to @nenkan/css
- keep existing .container fixed-width behavior unchanged
- document fixed vs fluid container usage in README

## Why
Consuming apps need a reusable fluid container option (Bootstrap-like container/container-fluid model) for data-heavy layouts and sidebar shells while preserving consistent responsive gutters.

## Design inspirations
- Bootstrap container vs container-fluid patterns
- Material/Fluent responsive margin ramps
